### PR TITLE
Remove track logging message

### DIFF
--- a/app/Console/Commands/PopulateTracksCommand.php
+++ b/app/Console/Commands/PopulateTracksCommand.php
@@ -58,7 +58,6 @@ class PopulateTracksCommand extends Command
         }
 
         activity()->log('Updated track data');
-        Log::info('tracks:populate command completed at time ' . now()->toDayDateTimeString());
         $this->info('Completed!');
     }
 }


### PR DESCRIPTION
removes this:
We're in big trouble
BOT
 — Today at 8:00 AM
:bulb: [2022-08-17 22:30:04] production.INFO
:black_small_square: tracks:populate command completed at time Wed, Aug 17, 2022 10:30 PM