### PR TITLE
Set max requests per child to 1000

### DIFF
--- a/docker/php-fpm.conf
+++ b/docker/php-fpm.conf
@@ -148,7 +148,7 @@ pm.max_spare_servers = 20
 ; This can be useful to work around memory leaks in 3rd party libraries. For
 ; endless request processing specify '0'. Equivalent to PHP_FCGI_MAX_REQUESTS.
 ; Default Value: 0
-;pm.max_requests = 500
+pm.max_requests = 1000
 
 ; The URI to view the FPM status page. If this value is not set, no URI will be
 ; recognized as a status page. It shows the following information:


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/1619328/93638472-fa7ec000-f9bc-11ea-8843-aa537f3ad86b.png)

We're seeing some slow memory growth on the natTrak k8s pods. Noticed this application wasn't set to recycle child processes after they've processed X number of requests, so set that to 1000.