### PR TITLE
bug: All CLXs being sent as RRs not tracks

### DIFF
--- a/app/Http/Controllers/Api/PluginDataController.php
+++ b/app/Http/Controllers/Api/PluginDataController.php
@@ -119,12 +119,28 @@ class PluginDataController extends Controller
         return response($tracks);
     }
 
+    private static function isOnTrackorRR(RclMessage $msg) {
+        if ($msg->latestClxMessage) {
+            if ($msg->latestClxMessage->track) {
+                return $msg->latestClxMessage->track->identifier;
+            } else {
+                return "RR";
+            }
+        } else {
+            if ($msg->track) {
+                return $msg->track->identifier;
+            } else {
+                return "RR";
+            }
+        }
+    }
+
     private static function serializeRclMessage(RclMessage $msg): array
     {
         return [
             'callsign' => $msg->callsign,
             'status' => $msg->clxMessages->count() ? 'CLEARED' : 'PENDING',
-            'nat' => $msg->latestClxMessage ? ($msg->latestClxMessage->track->identifer ?? 'RR') : $msg->track->identifier ?? 'RR',
+            'nat' => self::isOnTrackOrRr($msg),
             'fix' => $msg->latestClxMessage ? $msg->latestClxMessage->entry_fix : $msg->entry_fix,
             'level' => $msg->latestClxMessage ? $msg->latestClxMessage->flight_level : $msg->flight_level,
             'mach' => '0.'.substr($msg->mach, 1),

--- a/app/Http/Livewire/Controllers/ViewRclMessage.php
+++ b/app/Http/Livewire/Controllers/ViewRclMessage.php
@@ -101,7 +101,7 @@ class ViewRclMessage extends Component
 
         $newTrackAndEntryFix = null;
         if ($this->atcNewTrack != null || $this->atcNewRandomRouteing != null) {
-            $newTrackAndEntryFix = $service->getNewEntryTixAndOrTrack($this->atcNewTrack, $this->atcNewRandomRouteing);
+            $newTrackAndEntryFix = $service->getNewEntryFixOrTrack($this->atcNewTrack, $this->atcNewRandomRouteing);
         }
 
         $clxToOverride = $this->rclMessage->latestClxMessage?->id;
@@ -125,9 +125,16 @@ class ViewRclMessage extends Component
             $clxMessage->track_id = $this->atcNewTrack;
             $clxMessage->random_routeing = null;
         }
-        elseif ($this->atcNewRandomRouteing) {
+        else if ($this->atcNewRandomRouteing) {
             $clxMessage->random_routeing = strtoupper($this->atcNewRandomRouteing);
             $clxMessage->track_id = null;
+        }
+        else {
+            if ($this->rclMessage->random_routeing) {
+                $clxMessage->random_routeing = $this->rclMessage->random_routeing;
+            } else {
+                $clxMessage->track_id = $this->rclMessage->track_id;
+            }
         }
 
         $clxMessage->datalink_message = $service->createDatalinkMessage($clxMessage);

--- a/app/Services/ClxMessageService.php
+++ b/app/Services/ClxMessageService.php
@@ -24,7 +24,7 @@ class ClxMessageService
      * @return array
      * @throws InvalidTrackException
      */
-    public function getNewEntryTixAndOrTrack(?string $newTrackId, ?string $newRandomRouteing): array
+    public function getNewEntryFixOrTrack(?string $newTrackId, ?string $newRandomRouteing): array
     {
         $newTrack = null;
         $newEntryFix = null;


### PR DESCRIPTION
As per [Discord](https://discord.com/channels/775552633918062643/1228102732565450782/1444983701237661747). Without a specific workaround all CLXs were being issued as random routings regardless of if a track was selected or not. The column in the /plugins API has also been refined to be easier to maintain and a function spelling error fixed.