### PR TITLE
Fix: NAT track reporting after clearance

### DIFF
--- a/app/Http/Controllers/Api/PluginDataController.php
+++ b/app/Http/Controllers/Api/PluginDataController.php
@@ -58,7 +58,7 @@ class PluginDataController extends Controller
         );
     }
 
-    public function     detailedClxMessages(Request $request)
+    public function detailedClxMessages(Request $request)
     {
         $trackToSortBy = null;
         $requestAsksForTrack = false;
@@ -119,20 +119,27 @@ class PluginDataController extends Controller
         return response($tracks);
     }
 
-    private static function isOnTrackorRR(RclMessage $msg) {
+    private static function isOnTrackorRR(RclMessage $msg)
+    {
         if ($msg->latestClxMessage) {
             if ($msg->latestClxMessage->track) {
                 return $msg->latestClxMessage->track->identifier;
-            } else {
-                return "RR";
             }
-        } else {
+
+            // Fallback to the original RCL track if the CLX has no track
             if ($msg->track) {
                 return $msg->track->identifier;
-            } else {
-                return "RR";
             }
+
+            return 'RR';
         }
+
+        // No CLX yet: use the RCL track if present, otherwise RR
+        if ($msg->track) {
+            return $msg->track->identifier;
+        }
+
+        return 'RR';
     }
 
     private static function serializeRclMessage(RclMessage $msg): array


### PR DESCRIPTION
Fixes #192 
## Summary

Fix `/api/plugins` and `/api/plugins-rcl` NAT track reporting so that cleared aircraft retain their originally requested NAT track when the issued clearance does not explicitly assign a different track.

Previously, once an aircraft was CLEARED, the API would always report `"nat": "RR"` if the CLX message had no associated `track_id`, even when the original RCL message was filed on a published NAT track.

This PR updates the API serialization logic to fall back to the original RCL track when appropriate.

---

## Problem

When an aircraft transitions from **PENDING** to **CLEARED**:

- The API prefers the `latestClxMessage` for determining the NAT value
- If the CLX message has no `track_id`, the API reports `"RR"`
- This causes aircraft that were filed on a NAT track (e.g. Track G) to appear as random routing after clearance

This behavior affects downstream plugin consumers relying on `/api/plugins` for accurate NAT display.

---

## Solution

Update `PluginDataController::isOnTrackorRR()` to:

1. Prefer the CLX message track **when explicitly present**
2. Fall back to the original RCL track **when the CLX has no track**
3. Default to `"RR"` only when neither exists

This change affects **output only** and does not modify database state.

---

## Code Changes

**File:** `app/Http/Controllers/Api/PluginDataController.php`

```php
private static function isOnTrackorRR(RclMessage $msg)
{
    if ($msg->latestClxMessage) {
        if ($msg->latestClxMessage->track) {
            return $msg->latestClxMessage->track->identifier;
        }

        if ($msg->track) {
            return $msg->track->identifier;
        }

        return "RR";
    }

    if ($msg->track) {
        return $msg->track->identifier;
    }

    return "RR";
}